### PR TITLE
Enable binary sensor for specific bit in 16-bit register

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ uart:
 
 modbus_spy:
   id: modbusspy
-  log_not_configured_data: True
+  log_not_configured_data: true
   
 sensor:
   - platform: modbus_spy

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ uart:
 
 modbus_spy:
   id: modbusspy
+  log_not_configured_data: True
   
 sensor:
   - platform: modbus_spy

--- a/components/modbus_spy/binary_sensor.py
+++ b/components/modbus_spy/binary_sensor.py
@@ -12,14 +12,16 @@ ModbusBinarySensor = modbus_spy_ns.class_('ModbusBinarySensor', binary_sensor.Bi
 CONF_MODBUS_SPY_ID = 'modbus_spy_id'
 CONF_DEVICE_ADDRESS = 'device_address'
 CONF_REGISTER_ADDRESS = 'register_address'
+CONF_BIT = 'bit'
 
 CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
     cv.GenerateID(CONF_MODBUS_SPY_ID): cv.use_id(ModbusSpy),
     cv.Required(CONF_DEVICE_ADDRESS): int,
-    cv.Required(CONF_REGISTER_ADDRESS): int
+    cv.Required(CONF_REGISTER_ADDRESS): int,
+    cv.Optional(CONF_BIT, default=-1): int
 })
 
 async def to_code(config):
     modbus_spy = await cg.get_variable(config[CONF_MODBUS_SPY_ID])
-    modbus_binary_sensor = modbus_spy.create_binary_sensor(config[CONF_DEVICE_ADDRESS], config[CONF_REGISTER_ADDRESS])
+    modbus_binary_sensor = modbus_spy.create_binary_sensor(config[CONF_DEVICE_ADDRESS], config[CONF_REGISTER_ADDRESS], config[CONF_BIT])
     await binary_sensor.register_binary_sensor(modbus_binary_sensor, config)

--- a/components/modbus_spy/binary_sensor.py
+++ b/components/modbus_spy/binary_sensor.py
@@ -18,7 +18,7 @@ CONFIG_SCHEMA = binary_sensor.BINARY_SENSOR_SCHEMA.extend({
     cv.GenerateID(CONF_MODBUS_SPY_ID): cv.use_id(ModbusSpy),
     cv.Required(CONF_DEVICE_ADDRESS): int,
     cv.Required(CONF_REGISTER_ADDRESS): int,
-    cv.Optional(CONF_BIT, default=-1): int
+    cv.Optional(CONF_BIT, default=-1): cv.int_range(-1, 15)
 })
 
 async def to_code(config):

--- a/components/modbus_spy/modbus_binary_sensor.cpp
+++ b/components/modbus_spy/modbus_binary_sensor.cpp
@@ -1,5 +1,3 @@
-#ifndef UNIT_TEST
-
 #ifdef UNIT_TEST
 #include <test_includes.h>
 #else
@@ -18,6 +16,8 @@ static const char *TAG = "ModbusBinarySensor";
 IModbusBinarySensor::~IModbusBinarySensor() {
 }
 
+#ifndef UNIT_TEST
+
 ModbusBinarySensor::ModbusBinarySensor() {
   this->sensor_ = new binary_sensor::BinarySensor;
 }
@@ -35,7 +35,7 @@ binary_sensor::BinarySensor* ModbusBinarySensor::get_sensor() const {
   return this->sensor_;
 }
 
+#endif // UNIT_TEST
+
 } //namespace modbus_spy
 } //namespace esphome
-
-#endif // UNIT_TEST

--- a/components/modbus_spy/modbus_data_publisher.cpp
+++ b/components/modbus_spy/modbus_data_publisher.cpp
@@ -50,7 +50,8 @@ void ModbusDataPublisher::add_register_sensor(
 
 void ModbusDataPublisher::add_binary_sensor(
   uint8_t device_address, 
-  uint16_t register_address, 
+  uint16_t register_address,
+  int8_t bit,
   IModbusBinarySensor* binary_sensor
 ) {
   std::map<uint16_t, IModbusBinarySensor*> *binary_sensors_for_device = get_binary_sensors_for_device(device_address);

--- a/components/modbus_spy/modbus_data_publisher.cpp
+++ b/components/modbus_spy/modbus_data_publisher.cpp
@@ -54,7 +54,7 @@ void ModbusDataPublisher::add_binary_sensor(
   int8_t bit,
   IModbusBinarySensor* binary_sensor
 ) {
-  std::map<uint16_t, IModbusBinarySensor*> *binary_sensors_for_device = get_binary_sensors_for_device(device_address);
+  std::map<uint16_t, IModbusBinarySensor*> *binary_sensors_for_device = get_binary_sensors_full_register_for_device(device_address);
   binary_sensors_for_device->insert({ register_address, binary_sensor });
 }
 
@@ -68,14 +68,14 @@ std::map<uint16_t, IModbusRegisterSensor*>* ModbusDataPublisher::get_register_se
   return register_sensors_for_device;
 }
 
-std::map<uint16_t, IModbusBinarySensor*>* ModbusDataPublisher::get_binary_sensors_for_device(uint8_t device_address) {
+std::map<uint16_t, IModbusBinarySensor*>* ModbusDataPublisher::get_binary_sensors_full_register_for_device(uint8_t device_address) {
   DeviceSensors *sensors_for_device = get_sensors_for_device(device_address);
-  std::map<uint16_t, IModbusBinarySensor*>* binary_sensors_for_device = sensors_for_device->binary_sensors_;
-  if (nullptr == binary_sensors_for_device) {
-    binary_sensors_for_device = new std::map<uint16_t, IModbusBinarySensor*>;
-    sensors_for_device->binary_sensors_ = binary_sensors_for_device;
+  std::map<uint16_t, IModbusBinarySensor*>* binary_sensors_full_register_for_device = sensors_for_device->binary_sensors_full_register_;
+  if (nullptr == binary_sensors_full_register_for_device) {
+    binary_sensors_full_register_for_device = new std::map<uint16_t, IModbusBinarySensor*>;
+    sensors_for_device->binary_sensors_full_register_ = binary_sensors_full_register_for_device;
   }
-  return binary_sensors_for_device;
+  return binary_sensors_full_register_for_device;
 }
 
 ModbusDataPublisher::DeviceSensors* ModbusDataPublisher::get_sensors_for_device(uint8_t device_address) {
@@ -120,7 +120,7 @@ void ModbusDataPublisher::find_sensor_and_publish_data(uint8_t device_address, u
     register_sensor->publish_state(value);
   }
   if (!found_a_sensor) {
-    IModbusBinarySensor *binary_sensor = find_binary_sensor(device_address, data_model_register_address);
+    IModbusBinarySensor *binary_sensor = find_binary_sensor_full_register(device_address, data_model_register_address);
     if (binary_sensor != nullptr) {
       ESP_LOGV(TAG, "Found binary sensor! For register %d", data_model_register_address);
       found_a_sensor = true;
@@ -145,16 +145,16 @@ IModbusRegisterSensor* ModbusDataPublisher::find_register_sensor(uint8_t device_
   return register_sensors_for_device[data_model_register_address];
 }
 
-IModbusBinarySensor* ModbusDataPublisher::find_binary_sensor(uint8_t device_address, uint16_t data_model_register_address) {
+IModbusBinarySensor* ModbusDataPublisher::find_binary_sensor_full_register(uint8_t device_address, uint16_t data_model_register_address) {
   DeviceSensors *device_sensors = this->device_sensors_[device_address];
   if (nullptr == device_sensors) {
     return nullptr;
   }
-  if (nullptr == device_sensors->binary_sensors_) {
+  if (nullptr == device_sensors->binary_sensors_full_register_) {
     return nullptr;
   }
-  std::map<uint16_t, IModbusBinarySensor*>& binary_sensors_for_device = *device_sensors->binary_sensors_;
-  return binary_sensors_for_device[data_model_register_address];
+  std::map<uint16_t, IModbusBinarySensor*>& binary_sensors_full_register_for_device = *device_sensors->binary_sensors_full_register_;
+  return binary_sensors_full_register_for_device[data_model_register_address];
 }
 
 

--- a/components/modbus_spy/modbus_data_publisher.h
+++ b/components/modbus_spy/modbus_data_publisher.h
@@ -21,7 +21,7 @@ class IModbusDataPublisher {
  public:
   virtual ~IModbusDataPublisher();
   virtual void add_register_sensor(uint8_t device_address, uint16_t register_address, IModbusRegisterSensor* register_sensor) = 0;
-  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, IModbusBinarySensor* binary_sensor) = 0;
+  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit, IModbusBinarySensor* binary_sensor) = 0;
   virtual void publish_data(uint8_t device_address, uint8_t function, std::vector<ModbusData*>* data) = 0;
 };
 
@@ -42,7 +42,7 @@ class ModbusDataPublisher : public IModbusDataPublisher {
   virtual ~ModbusDataPublisher() override;
   
   virtual void add_register_sensor(uint8_t device_address, uint16_t register_address, IModbusRegisterSensor* register_sensor) override;
-  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, IModbusBinarySensor* binary_sensor) override;
+  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit, IModbusBinarySensor* binary_sensor) override;
   virtual void publish_data(uint8_t device_address, uint8_t function, std::vector<ModbusData*>* data) override;
 
  protected:

--- a/components/modbus_spy/modbus_data_publisher.h
+++ b/components/modbus_spy/modbus_data_publisher.h
@@ -29,7 +29,7 @@ class ModbusDataPublisher : public IModbusDataPublisher {
  private:
   typedef struct DeviceSensors {
     std::map<uint16_t, IModbusRegisterSensor*>* register_sensors_ { nullptr };
-    std::map<uint16_t, IModbusBinarySensor*>* binary_sensors_ { nullptr };
+    std::map<uint16_t, IModbusBinarySensor*>* binary_sensors_full_register_ { nullptr };
   } DeviceSensors;
 
  public:
@@ -49,13 +49,13 @@ class ModbusDataPublisher : public IModbusDataPublisher {
   std::map<uint8_t, DeviceSensors*> device_sensors_;
   bool should_dump_not_configured_data_ { false };
   IModbusRegisterSensor* find_register_sensor(uint8_t device_address, uint16_t data_model_register_address);
-  IModbusBinarySensor* find_binary_sensor(uint8_t device_address, uint16_t data_model_register_address);
+  IModbusBinarySensor* find_binary_sensor_full_register(uint8_t device_address, uint16_t data_model_register_address);
 
  private:
   uint16_t convert_pdu_address_to_data_model_address(uint8_t function, uint16_t pdu_address);
   void find_sensor_and_publish_data(uint8_t device_address, uint16_t data_model_register_address, uint16_t value);
   std::map<uint16_t, IModbusRegisterSensor*>* get_register_sensors_for_device(uint8_t device_address);
-  std::map<uint16_t, IModbusBinarySensor*>* get_binary_sensors_for_device(uint8_t device_address);
+  std::map<uint16_t, IModbusBinarySensor*>* get_binary_sensors_full_register_for_device(uint8_t device_address);
   DeviceSensors* get_sensors_for_device(uint8_t device_address);
 };
 

--- a/components/modbus_spy/modbus_data_publisher.h
+++ b/components/modbus_spy/modbus_data_publisher.h
@@ -30,6 +30,7 @@ class ModbusDataPublisher : public IModbusDataPublisher {
   typedef struct DeviceSensors {
     std::map<uint16_t, IModbusRegisterSensor*>* register_sensors_ { nullptr };
     std::map<uint16_t, IModbusBinarySensor*>* binary_sensors_full_register_ { nullptr };
+    std::map<uint16_t, IModbusBinarySensor**>* binary_sensors_bit_ { nullptr };
   } DeviceSensors;
 
  public:
@@ -50,12 +51,14 @@ class ModbusDataPublisher : public IModbusDataPublisher {
   bool should_dump_not_configured_data_ { false };
   IModbusRegisterSensor* find_register_sensor(uint8_t device_address, uint16_t data_model_register_address);
   IModbusBinarySensor* find_binary_sensor_full_register(uint8_t device_address, uint16_t data_model_register_address);
+  IModbusBinarySensor** find_binary_bit_sensors(uint8_t device_address, uint16_t data_model_register_address);
 
  private:
   uint16_t convert_pdu_address_to_data_model_address(uint8_t function, uint16_t pdu_address);
   void find_sensor_and_publish_data(uint8_t device_address, uint16_t data_model_register_address, uint16_t value);
   std::map<uint16_t, IModbusRegisterSensor*>* get_register_sensors_for_device(uint8_t device_address);
   std::map<uint16_t, IModbusBinarySensor*>* get_binary_sensors_full_register_for_device(uint8_t device_address);
+  std::map<uint16_t, IModbusBinarySensor**>* get_binary_sensors_bit_for_device(uint8_t device_address);
   DeviceSensors* get_sensors_for_device(uint8_t device_address);
 };
 

--- a/components/modbus_spy/modbus_register_sensor.cpp
+++ b/components/modbus_spy/modbus_register_sensor.cpp
@@ -1,5 +1,3 @@
-#ifndef UNIT_TEST
-
 #ifdef UNIT_TEST
 #include <test_includes.h>
 #else
@@ -18,6 +16,8 @@ static const char *TAG = "ModbusRegisterSensor";
 IModbusRegisterSensor::~IModbusRegisterSensor() {
 }
 
+#ifndef UNIT_TEST
+
 ModbusRegisterSensor::ModbusRegisterSensor() {
   this->sensor_ = new sensor::Sensor;
 }
@@ -35,7 +35,7 @@ sensor::Sensor* ModbusRegisterSensor::get_sensor() const {
   return this->sensor_;
 }
 
+#endif // UNIT_TEST
+
 } //namespace modbus_spy
 } //namespace esphome
-
-#endif // UNIT_TEST

--- a/components/modbus_spy/modbus_spy.cpp
+++ b/components/modbus_spy/modbus_spy.cpp
@@ -35,7 +35,7 @@ binary_sensor::BinarySensor* ModbusSpy::create_binary_sensor(
   int8_t bit
 ) {
   ModbusBinarySensor *binary_sensor = new ModbusBinarySensor();
-  this->data_publisher_.add_binary_sensor(device_address, register_address, binary_sensor);
+  this->data_publisher_.add_binary_sensor(device_address, register_address, bit, binary_sensor);
   return binary_sensor->get_sensor();
 }
 

--- a/components/modbus_spy/modbus_spy.cpp
+++ b/components/modbus_spy/modbus_spy.cpp
@@ -29,7 +29,11 @@ sensor::Sensor* ModbusSpy::create_sensor(uint8_t device_address, uint16_t regist
   return register_sensor->get_sensor();
 }
 
-binary_sensor::BinarySensor* ModbusSpy::create_binary_sensor(uint8_t device_address, uint16_t register_address) {
+binary_sensor::BinarySensor* ModbusSpy::create_binary_sensor(
+  uint8_t device_address,
+  uint16_t register_address,
+  int8_t bit
+) {
   ModbusBinarySensor *binary_sensor = new ModbusBinarySensor();
   this->data_publisher_.add_binary_sensor(device_address, register_address, binary_sensor);
   return binary_sensor->get_sensor();

--- a/components/modbus_spy/modbus_spy.h
+++ b/components/modbus_spy/modbus_spy.h
@@ -28,7 +28,7 @@ class ModbusSpy : public Component, public uart::UARTDevice {
   float get_setup_priority() const override;
   uint32_t get_baud_rate() const { return parent_->get_baud_rate(); }
   sensor::Sensor* create_sensor(uint8_t device_address, uint16_t register_address);
-  binary_sensor::BinarySensor* create_binary_sensor(uint8_t device_address, uint16_t register_address);
+  binary_sensor::BinarySensor* create_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit);
 
  protected:
   ModbusSniffer* sniffer_;

--- a/example.yaml
+++ b/example.yaml
@@ -61,7 +61,7 @@ uart:
 
 modbus_spy:
   id: modbusspy
-  log_not_configured_data: False
+  log_not_configured_data: false
 
 dallas:
   - pin: GPIO27  

--- a/example.yaml
+++ b/example.yaml
@@ -342,6 +342,24 @@ sensor:
 
 binary_sensor:
   - platform: modbus_spy
+    id: defrost_value1_bit2
+    device_address: 0x02
+    register_address: 42109
+    bit: 2
+    name: "Defrost value1 bit 2"
+  - platform: modbus_spy
+    id: defrost_value1_bit6
+    device_address: 0x02
+    register_address: 42109
+    bit: 6
+    name: "Defrost value1 bit 6"
+  - platform: modbus_spy
+    id: defrost_value3_bit11
+    device_address: 0x02
+    register_address: 42120
+    bit: 11
+    name: "Defrost value3 bit 11"
+  - platform: modbus_spy
     name: "Pump 1 Active"
     device_address: 0x0B
     register_address: 41301

--- a/more-info.md
+++ b/more-info.md
@@ -74,7 +74,7 @@ Error and exception codes are not supported explicitly. If a response can be mat
 ### How to find the register addresses
 
 - Vendor documentation (if available)
-- Set log level to INFO and add "log_not_configured_data: True" to the modbus_spy config  
+- Set log level to INFO and add "log_not_configured_data: true" to the modbus_spy config  
 The component will log all registers it detects and supports, e.g.:  
 `Finding sensor for register address 42100, to publish value 5102`
 - Black magic

--- a/more-info.md
+++ b/more-info.md
@@ -74,7 +74,7 @@ Error and exception codes are not supported explicitly. If a response can be mat
 ### How to find the register addresses
 
 - Vendor documentation (if available)
-- Set log level to DEBUG  
+- Set log level to INFO and add "log_not_configured_data: True" to the modbus_spy config  
 The component will log all registers it detects and supports, e.g.:  
 `Finding sensor for register address 42100, to publish value 5102`
 - Black magic

--- a/test/fake_modbus_data_publisher.h
+++ b/test/fake_modbus_data_publisher.h
@@ -26,7 +26,7 @@ class FakeModbusDataPublisher : public IModbusDataPublisher {
   virtual ~FakeModbusDataPublisher() override;
   virtual void publish_data(uint8_t device_address, uint8_t function, std::vector<ModbusData*>* data);
   virtual void add_register_sensor(uint8_t device_address, uint16_t register_address, IModbusRegisterSensor* register_sensor) override {}
-  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, IModbusBinarySensor* binary_sensor) override {}
+  virtual void add_binary_sensor(uint8_t device_address, uint16_t register_address, int8_t bit, IModbusBinarySensor* binary_sensor) override {}
   vector<PublishedData*>* get_published_data() { return &this->published_data_; }
   
  protected:

--- a/test/test_modbus_data_publisher/fake_modbus_binary_sensor.cpp
+++ b/test/test_modbus_data_publisher/fake_modbus_binary_sensor.cpp
@@ -1,8 +1,5 @@
 #include "fake_modbus_binary_sensor.h"
 
-FakeModbusBinarySensor::~FakeModbusBinarySensor() {
-}
-
 void FakeModbusBinarySensor::publish_state(bool state) {
   this->published_states_.push_back(state);
 }

--- a/test/test_modbus_data_publisher/fake_modbus_binary_sensor.cpp
+++ b/test/test_modbus_data_publisher/fake_modbus_binary_sensor.cpp
@@ -1,0 +1,12 @@
+#include "fake_modbus_binary_sensor.h"
+
+FakeModbusBinarySensor::~FakeModbusBinarySensor() {
+}
+
+void FakeModbusBinarySensor::publish_state(bool state) {
+  this->published_states_.push_back(state);
+}
+
+vector<bool>* FakeModbusBinarySensor::get_published_states() {
+  return &this->published_states_;
+}

--- a/test/test_modbus_data_publisher/fake_modbus_binary_sensor.h
+++ b/test/test_modbus_data_publisher/fake_modbus_binary_sensor.h
@@ -10,7 +10,6 @@ using esphome::modbus_spy::IModbusBinarySensor;
 
 class FakeModbusBinarySensor : public IModbusBinarySensor {
  public:
-  virtual ~FakeModbusBinarySensor() override;
   virtual void publish_state(bool state) override;
   vector<bool>* get_published_states();
  protected:

--- a/test/test_modbus_data_publisher/fake_modbus_binary_sensor.h
+++ b/test/test_modbus_data_publisher/fake_modbus_binary_sensor.h
@@ -1,0 +1,21 @@
+#ifndef FAKE_MODBUS_BINARY_SENSOR_
+#define FAKE_MODBUS_BINARY_SENSOR_
+
+#include <vector>
+
+#include "modbus_binary_sensor.h"
+
+using std::vector;
+using esphome::modbus_spy::IModbusBinarySensor;
+
+class FakeModbusBinarySensor : public IModbusBinarySensor {
+ public:
+  virtual ~FakeModbusBinarySensor() override;
+  virtual void publish_state(bool state) override;
+  vector<bool>* get_published_states();
+ protected:
+  vector<bool> published_states_;
+};
+
+
+#endif // FAKE_MODBUS_BINARY_SENSOR_

--- a/test/test_modbus_data_publisher/fake_modbus_register_sensor.h
+++ b/test/test_modbus_data_publisher/fake_modbus_register_sensor.h
@@ -10,7 +10,6 @@ using esphome::modbus_spy::IModbusRegisterSensor;
 
 class FakeModbusRegisterSensor : public IModbusRegisterSensor {
  public:
-  virtual ~FakeModbusRegisterSensor() override;
   virtual void publish_state(uint16_t state) override;
   vector<uint16_t>* get_published_states();
  protected:

--- a/test/test_modbus_data_publisher/test_modbus_data_publisher.cpp
+++ b/test/test_modbus_data_publisher/test_modbus_data_publisher.cpp
@@ -138,9 +138,9 @@ void test_publish_data_binary_flag_sensors() {
   FakeModbusBinarySensor *fakeBinarySensorBit0 = new FakeModbusBinarySensor;
   data_publisher.add_binary_sensor(device_address, register_address + 40001, 0, fakeBinarySensorBit0);
   FakeModbusBinarySensor *fakeBinarySensorBit1 = new FakeModbusBinarySensor;
-  data_publisher.add_binary_sensor(device_address, register_address + 40001, 1, fakeBinarySensorBit0);
+  data_publisher.add_binary_sensor(device_address, register_address + 40001, 1, fakeBinarySensorBit1);
   FakeModbusBinarySensor *fakeBinarySensorBit15 = new FakeModbusBinarySensor;
-  data_publisher.add_binary_sensor(device_address, register_address + 40001, 15, fakeBinarySensorBit0);
+  data_publisher.add_binary_sensor(device_address, register_address + 40001, 15, fakeBinarySensorBit15);
 
   // Act
   data_publisher.publish_data(device_address, function, data);
@@ -154,7 +154,7 @@ void test_publish_data_binary_flag_sensors() {
 void assert_binary_sensor_for_bit(FakeModbusBinarySensor* sensor, uint8_t bit, uint16_t register_value) {
   vector<bool> *published_states = sensor->get_published_states();
   TEST_ASSERT_EQUAL_UINT8(1, published_states->size());
-  bool expected_value = (register_value & (1 << 0)) >> 0;
+  bool expected_value = (register_value & (1 << bit)) >> bit;
   bool actual_value = published_states->at(0);
   if (expected_value) {
     TEST_ASSERT_TRUE(actual_value);

--- a/test/test_modbus_data_publisher/test_modbus_data_publisher.cpp
+++ b/test/test_modbus_data_publisher/test_modbus_data_publisher.cpp
@@ -99,27 +99,51 @@ void test_publish_data_function_3() {
   // Arrange
   const uint8_t device_address = 0x02;
   const int8_t function = 3;
-  const uint16_t register_address = 0x01AF;
-  const uint16_t register_value = 0x3210;
   ModbusDataPublisher data_publisher;
   vector<ModbusData*> *data = new vector<ModbusData*>;
-  ModbusData *modbus_data = new ModbusData;
-  modbus_data->address = register_address;
-  modbus_data->value = 0x3210;
-  data->push_back(modbus_data);
+  const uint16_t register_address_1 = 0x01AF;
+  const uint16_t register_value_1 = 0x3210;
+  ModbusData *modbus_data_1 = new ModbusData;
+  modbus_data_1->address = register_address_1;
+  modbus_data_1->value = register_value_1;
+  data->push_back(modbus_data_1);
+  const uint16_t register_address_2 = 0x01B0;
+  const uint16_t register_value_2 = 1;
+  ModbusData *modbus_data_2 = new ModbusData;
+  modbus_data_2->address = register_address_2;
+  modbus_data_2->value = register_value_2;
+  data->push_back(modbus_data_2);
+  const uint16_t register_address_3 = 0x01B1;
+  const uint16_t register_value_3 = 0b10;
+  ModbusData *modbus_data_3 = new ModbusData;
+  modbus_data_3->address = register_address_3;
+  modbus_data_3->value = register_value_3;
+  data->push_back(modbus_data_3);
 
-  FakeModbusRegisterSensor *fakeRegisterSensor = new FakeModbusRegisterSensor;
-  data_publisher.add_register_sensor(device_address, register_address + 40001, fakeRegisterSensor);
+  FakeModbusRegisterSensor *fake_register_sensor = new FakeModbusRegisterSensor;
+  data_publisher.add_register_sensor(device_address, register_address_1 + 40001, fake_register_sensor);
+  FakeModbusBinarySensor *fake_binary_full_register_sensor = new FakeModbusBinarySensor;
+  data_publisher.add_binary_sensor(device_address, register_address_2 + 40001, -1, fake_binary_full_register_sensor);
+  FakeModbusBinarySensor *fake_binary_bit_sensor = new FakeModbusBinarySensor;
+  data_publisher.add_binary_sensor(device_address, register_address_3 + 40001, 1, fake_binary_bit_sensor);
 
   // Act
   data_publisher.publish_data(device_address, function, data);
 
   // Assert
-  vector<uint16_t> *published_states = fakeRegisterSensor->get_published_states();
-  TEST_ASSERT_EQUAL_UINT8(1, published_states->size());
-  uint16_t expected_value = register_value;
-  uint16_t actual_value = published_states->at(0);
+  vector<uint16_t> *published_states_1 = fake_register_sensor->get_published_states();
+  TEST_ASSERT_EQUAL_UINT8(1, published_states_1->size());
+  uint16_t expected_value = register_value_1;
+  uint16_t actual_value = published_states_1->at(0);
   TEST_ASSERT_EQUAL_UINT16(expected_value, actual_value);
+
+  vector<bool> *published_states_2 = fake_binary_full_register_sensor->get_published_states();
+  TEST_ASSERT_EQUAL_UINT8(1, published_states_2->size());
+  TEST_ASSERT_TRUE(published_states_2->at(0));
+
+  vector<bool> *published_states_3 = fake_binary_bit_sensor->get_published_states();
+  TEST_ASSERT_EQUAL_UINT8(1, published_states_3->size());
+  TEST_ASSERT_TRUE(published_states_3->at(0));
 }
 
 void test_publish_data_binary_flag_sensors() {

--- a/test/test_modbus_data_publisher/testable_modbus_data_publisher.h
+++ b/test/test_modbus_data_publisher/testable_modbus_data_publisher.h
@@ -1,9 +1,11 @@
 #ifndef TESTABLE_MODBUS_DATA_PUBLISHER_
 #define TESTABLE_MODBUS_DATA_PUBLISHER_
 
+#include "modbus_binary_sensor.h"
 #include "modbus_data_publisher.h"
 #include "modbus_register_sensor.h"
 
+using esphome::modbus_spy::IModbusBinarySensor;
 using esphome::modbus_spy::ModbusDataPublisher;
 using esphome::modbus_spy::IModbusRegisterSensor;
 


### PR DESCRIPTION
This PR introduces the possibility to configure a binary_sensor for a specific bit in a 16-bit register.
Until now it was only possible to have a binary_sensor that looked at the entire 16-bit register.

binary_sensor can have a 'bit' configured. By default it's -1, which results in the existing behavior.



~~TODO: Extend config validation to ensure that the bit value is in the range [-1;15]~~