### PR TITLE
Fix issue #3: Cannot compile if no binary_sensor defined

### DIFF
--- a/components/modbus_spy/__init__.py
+++ b/components/modbus_spy/__init__.py
@@ -6,6 +6,7 @@ from esphome.components import uart
 CODEOWNERS = ["@pdjong"]
 
 DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["binary_sensor"]
 MULTI_CONF = True
 
 modbus_spy_ns = cg.esphome_ns.namespace('modbus_spy')


### PR DESCRIPTION
Fixed by auto loading binary_sensor